### PR TITLE
Ant 27 camera click dragging --- Merged with ant 35

### DIFF
--- a/core/src/aaa/main/game/CameraInputProcessor.java
+++ b/core/src/aaa/main/game/CameraInputProcessor.java
@@ -62,12 +62,20 @@ public class CameraInputProcessor implements InputProcessor {
 
     @Override
     public boolean touchDown(int screenX, int screenY, int pointer, int button) {
-        return false;
+        //save the position of the touch
+        Vector3 worldPos = camera.unproject(new Vector3(screenX, screenY, 0));
+        lastX = worldPos.x;
+        lastY = worldPos.y;
+        return true;
     }
 
     @Override
     public boolean touchUp(int screenX, int screenY, int pointer, int button) {
-        return false;
+        //save the position of the touch
+        Vector3 worldPos = camera.unproject(new Vector3(screenX, screenY, 0));
+        lastX = worldPos.x;
+        lastY = worldPos.y;
+        return true;
     }
 
     @Override
@@ -80,18 +88,7 @@ public class CameraInputProcessor implements InputProcessor {
         // convert the screen coordinates to world coordinates
         Vector3 worldPos = camera.unproject(new Vector3(screenX, screenY, 0));
 
-        // get the change in position
-        float deltaX = worldPos.x - lastX;
-        float deltaY = worldPos.y - lastY;
-
-        // move the camera by the change in position
-        camera.translate(-deltaX, -deltaY);
-
-        // store the new position
-        lastX = worldPos.x;
-        lastY = worldPos.y;
-
-
+        camera.translate(lastX - worldPos.x, lastY - worldPos.y);
         return true;
     }
 

--- a/core/src/aaa/main/game/CameraInputProcessor.java
+++ b/core/src/aaa/main/game/CameraInputProcessor.java
@@ -6,10 +6,13 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.math.Vector3;
+import aaa.main.screens.MainScreen;
 
 
 public class CameraInputProcessor implements InputProcessor {
     private OrthographicCamera camera;
+    private float lastX, lastY;
 
     public CameraInputProcessor(OrthographicCamera camera) {
         this.camera = camera;
@@ -17,8 +20,6 @@ public class CameraInputProcessor implements InputProcessor {
 
     @Override
     public boolean keyDown(int keycode) {
-
-
         //Camera zoom controls
         if (keycode == Input.Keys.MINUS && camera.zoom <= Constants.MAX_ZOOM) {
             //zoom out
@@ -76,7 +77,22 @@ public class CameraInputProcessor implements InputProcessor {
 
     @Override
     public boolean touchDragged(int screenX, int screenY, int pointer) {
-        return false;
+        // convert the screen coordinates to world coordinates
+        Vector3 worldPos = camera.unproject(new Vector3(screenX, screenY, 0));
+
+        // get the change in position
+        float deltaX = worldPos.x - lastX;
+        float deltaY = worldPos.y - lastY;
+
+        // move the camera by the change in position
+        camera.translate(-deltaX, -deltaY);
+
+        // store the new position
+        lastX = worldPos.x;
+        lastY = worldPos.y;
+
+
+        return true;
     }
 
     @Override

--- a/core/src/aaa/main/game/CameraInputProcessor.java
+++ b/core/src/aaa/main/game/CameraInputProcessor.java
@@ -9,6 +9,8 @@ import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.math.Vector3;
 import aaa.main.screens.MainScreen;
 
+import static aaa.main.util.Constants.CAMERA_MOVE_SPEED;
+
 
 public class CameraInputProcessor implements InputProcessor {
     private OrthographicCamera camera;
@@ -18,6 +20,7 @@ public class CameraInputProcessor implements InputProcessor {
         this.camera = camera;
     }
 
+    //handler for horizontal/vertical movement
     @Override
     public boolean keyDown(int keycode) {
         //Camera zoom controls
@@ -29,24 +32,44 @@ public class CameraInputProcessor implements InputProcessor {
             camera.zoom -= 0.02f;
         }
 
-        //move camera based on arrow keys (doesnt work when set to ortho)
-        //test msg
-        /*
+        //Camera movement controls
         if (keycode == Input.Keys.LEFT) {
             //move left
-            camera.translate(-32, 0);
-        } else if (keycode == Input.Keys.RIGHT) {
-            //move right
-            camera.translate(32, 0);
-        } else if (keycode == Input.Keys.UP) {
-            //move up
-            camera.translate(0, 32);
-        } else if (keycode == Input.Keys.DOWN) {
-            //move down
-            camera.translate(0, -32);
+            camera.translate(-CAMERA_MOVE_SPEED, 0);
         }
-        */
+        if (keycode == Input.Keys.RIGHT) {
+            //move right
+            camera.translate(CAMERA_MOVE_SPEED, 0);
+        }
+        if (keycode == Input.Keys.UP) {
+            //move up
+            camera.translate(0, CAMERA_MOVE_SPEED);
+        }
+        if (keycode == Input.Keys.DOWN) {
+            //move down
+            camera.translate(0, -CAMERA_MOVE_SPEED);
+        }
+        return false;
+    }
 
+    //handler for diagonal movement
+    public boolean keyDown2(int keycode, float modifier) {
+        if (keycode == Input.Keys.LEFT) {
+            //move left
+            camera.translate(-CAMERA_MOVE_SPEED/modifier, 0);
+        }
+        if (keycode == Input.Keys.RIGHT) {
+            //move right
+            camera.translate(CAMERA_MOVE_SPEED/modifier, 0);
+        }
+        if (keycode == Input.Keys.UP) {
+            //move up
+            camera.translate(0, CAMERA_MOVE_SPEED/modifier);
+        }
+        if (keycode == Input.Keys.DOWN) {
+            //move down
+            camera.translate(0, -CAMERA_MOVE_SPEED/modifier);
+        }
         return false;
     }
 
@@ -62,20 +85,15 @@ public class CameraInputProcessor implements InputProcessor {
 
     @Override
     public boolean touchDown(int screenX, int screenY, int pointer, int button) {
-        //save the position of the touch
-        Vector3 worldPos = camera.unproject(new Vector3(screenX, screenY, 0));
-        lastX = worldPos.x;
-        lastY = worldPos.y;
-        return true;
+        //logic for switching player context should be to check if position clicked is on a object
+        //checks would have to be in world coordinates, not screen coordinates
+        //also would need to check for clicks on UI buttons, should be in screen coordinates then
+        return false;
     }
 
     @Override
     public boolean touchUp(int screenX, int screenY, int pointer, int button) {
-        //save the position of the touch
-        Vector3 worldPos = camera.unproject(new Vector3(screenX, screenY, 0));
-        lastX = worldPos.x;
-        lastY = worldPos.y;
-        return true;
+        return false;
     }
 
     @Override
@@ -85,11 +103,7 @@ public class CameraInputProcessor implements InputProcessor {
 
     @Override
     public boolean touchDragged(int screenX, int screenY, int pointer) {
-        // convert the screen coordinates to world coordinates
-        Vector3 worldPos = camera.unproject(new Vector3(screenX, screenY, 0));
-
-        camera.translate(lastX - worldPos.x, lastY - worldPos.y);
-        return true;
+        return false;
     }
 
     @Override

--- a/core/src/aaa/main/game/PlayerInputProcessor.java
+++ b/core/src/aaa/main/game/PlayerInputProcessor.java
@@ -4,6 +4,8 @@ import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.physics.box2d.Body;
 
+import static aaa.main.util.Constants.PLAYER_MOVE_SPEED;
+
 public class PlayerInputProcessor implements InputProcessor {
     private float horizontalVelocity;
     private float verticalVelocity;
@@ -12,24 +14,57 @@ public class PlayerInputProcessor implements InputProcessor {
     public PlayerInputProcessor(Body player) {
         this.player = player;
     }
+
+    //handler for horizontal/vertical movement
     @Override
     public boolean keyDown(int keycode) {
 
         horizontalVelocity = 0;
         verticalVelocity = 0;
 
-        if (keycode == Input.Keys.LEFT) {
+        if (keycode == Input.Keys.A) {
             //move left
-            horizontalVelocity = -5;
-        } else if (keycode == Input.Keys.RIGHT) {
+            horizontalVelocity = -PLAYER_MOVE_SPEED;
+        }
+        if (keycode == Input.Keys.D) {
             //move right
-            horizontalVelocity = 5;
-        } else if (keycode == Input.Keys.UP) {
+            horizontalVelocity = PLAYER_MOVE_SPEED;
+        }
+        if (keycode == Input.Keys.W) {
             //move up
-            verticalVelocity = 5;
-        } else if (keycode == Input.Keys.DOWN) {
+            verticalVelocity = PLAYER_MOVE_SPEED;
+        }
+        if (keycode == Input.Keys.S) {
             //move down
-            verticalVelocity = -5;
+            verticalVelocity = -PLAYER_MOVE_SPEED;
+        }
+
+        player.setLinearVelocity(horizontalVelocity, verticalVelocity);
+
+        return false;
+    }
+
+    //handler for diagonal movement
+    public boolean keyDown2(int keycode1, int keycode2, float speedModifier) {
+
+        horizontalVelocity = 0;
+        verticalVelocity = 0;
+
+        if (keycode1 == Input.Keys.A && keycode2 == Input.Keys.W) {
+            horizontalVelocity = -PLAYER_MOVE_SPEED * speedModifier;
+            verticalVelocity = PLAYER_MOVE_SPEED * speedModifier;
+        }
+        if (keycode1 == Input.Keys.A && keycode2 == Input.Keys.S) {
+            horizontalVelocity = -PLAYER_MOVE_SPEED * speedModifier;
+            verticalVelocity = -PLAYER_MOVE_SPEED * speedModifier;
+        }
+        if (keycode1 == Input.Keys.D && keycode2 == Input.Keys.W) {
+            horizontalVelocity = PLAYER_MOVE_SPEED * speedModifier;
+            verticalVelocity = PLAYER_MOVE_SPEED * speedModifier;
+        }
+        if (keycode1 == Input.Keys.D && keycode2 == Input.Keys.S) {
+            horizontalVelocity = PLAYER_MOVE_SPEED * speedModifier;
+            verticalVelocity = -PLAYER_MOVE_SPEED * speedModifier;
         }
 
         player.setLinearVelocity(horizontalVelocity, verticalVelocity);

--- a/core/src/aaa/main/screens/MainScreen.java
+++ b/core/src/aaa/main/screens/MainScreen.java
@@ -33,7 +33,7 @@ public class MainScreen extends ScreenAdapter {
     private OrthographicCamera cameraBox2D;
     private OrthographicCamera camera;
     private World world;
-    private Body player,borderUP, borderDOWN, borderLEFT, borderRIGHT;
+    private Body player ,borderUP, borderDOWN, borderLEFT, borderRIGHT, circle;
     private final float SCALE = 2.0f;
     CameraInputProcessor cameraInputProcessor;
     PlayerInputProcessor playerInputProcessor;
@@ -42,7 +42,6 @@ public class MainScreen extends ScreenAdapter {
 
         this.game = game;
         stage = new Stage();
-
 
         //Camera initilization
         camera = new OrthographicCamera();

--- a/core/src/aaa/main/screens/MainScreen.java
+++ b/core/src/aaa/main/screens/MainScreen.java
@@ -1,7 +1,6 @@
 package aaa.main.screens;
 
 import aaa.main.AntGame;
-import aaa.main.game.Colony;
 import aaa.main.game.PlayerInputProcessor;
 import aaa.main.stages.PauseMenu;
 import aaa.main.game.CameraInputProcessor;
@@ -31,7 +30,6 @@ public class MainScreen extends ScreenAdapter {
     private final Stage stage;
     private boolean pauseOpened = false;
 
-
     private boolean DEBUG = false;
     private Box2DDebugRenderer b2dr;
     private OrthographicCamera camera;
@@ -45,7 +43,6 @@ public class MainScreen extends ScreenAdapter {
     CameraInputProcessor cameraInputProcessor;
     PlayerInputProcessor playerInputProcessor;
     InputMultiplexer inputMultiplexer;
-    private final Colony[] antColonies = new Colony[GLOBAL_MAX_COLONY];
     public MainScreen(final AntGame game) {
         inputMultiplexer = new InputMultiplexer();
 
@@ -56,7 +53,7 @@ public class MainScreen extends ScreenAdapter {
         camera = new OrthographicCamera();
         camera.setToOrtho(false, SCREEN_WIDTH / SCALE , SCREEN_HEIGHT / SCALE);
 
-        Gdx.input.setInputProcessor(cameraInputProcessor);
+        //Gdx.input.setInputProcessor(cameraInputProcessor);
         this.cameraInputProcessor = new CameraInputProcessor(camera);
 
         //World/debug renderer initialization
@@ -182,18 +179,71 @@ public class MainScreen extends ScreenAdapter {
             cameraInputProcessor.keyDown(Input.Keys.MINUS);
         }
 
-        //Player inputs
+        //camera controlls with arrow keys
         if (Gdx.input.isKeyPressed(Input.Keys.LEFT) || Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.LEFT)) {
-            playerInputProcessor.keyDown(Input.Keys.LEFT);
+            cameraInputProcessor.keyDown(Input.Keys.LEFT);
         } else if (Gdx.input.isKeyPressed(Input.Keys.RIGHT) || Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.RIGHT)) {
-            playerInputProcessor.keyDown(Input.Keys.RIGHT);
+            cameraInputProcessor.keyDown(Input.Keys.RIGHT);
         } else if (Gdx.input.isKeyPressed(Input.Keys.UP) || Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.UP)) {
-            playerInputProcessor.keyDown(Input.Keys.UP);
+            cameraInputProcessor.keyDown(Input.Keys.UP);
         } else if (Gdx.input.isKeyPressed(Input.Keys.DOWN) || Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.DOWN)) {
-            playerInputProcessor.keyDown(Input.Keys.DOWN);
-        } else {
-            playerInputProcessor.resetVelocity();
+            cameraInputProcessor.keyDown(Input.Keys.DOWN);
         }
+
+        //if 2 keys pressed at the same time, move diagonally (camera)
+        if (Gdx.input.isKeyPressed(Input.Keys.LEFT) && Gdx.input.isKeyPressed(Input.Keys.UP)) {
+            cameraInputProcessor.keyDown2(Input.Keys.LEFT, CAMERA_DIAGONAL_MOVE_SPEED_MODIFIER);
+            cameraInputProcessor.keyDown2(Input.Keys.UP, CAMERA_DIAGONAL_MOVE_SPEED_MODIFIER);
+        }
+        if (Gdx.input.isKeyPressed(Input.Keys.RIGHT) && Gdx.input.isKeyPressed(Input.Keys.UP)) {
+            cameraInputProcessor.keyDown2(Input.Keys.RIGHT, CAMERA_DIAGONAL_MOVE_SPEED_MODIFIER);
+            cameraInputProcessor.keyDown2(Input.Keys.UP, CAMERA_DIAGONAL_MOVE_SPEED_MODIFIER);
+        }
+        if (Gdx.input.isKeyPressed(Input.Keys.LEFT) && Gdx.input.isKeyPressed(Input.Keys.DOWN)) {
+            cameraInputProcessor.keyDown2(Input.Keys.LEFT, CAMERA_DIAGONAL_MOVE_SPEED_MODIFIER);
+            cameraInputProcessor.keyDown2(Input.Keys.DOWN, CAMERA_DIAGONAL_MOVE_SPEED_MODIFIER);
+        }
+        if (Gdx.input.isKeyPressed(Input.Keys.RIGHT) && Gdx.input.isKeyPressed(Input.Keys.DOWN)) {
+            cameraInputProcessor.keyDown2(Input.Keys.RIGHT, CAMERA_DIAGONAL_MOVE_SPEED_MODIFIER);
+            cameraInputProcessor.keyDown2(Input.Keys.DOWN, CAMERA_DIAGONAL_MOVE_SPEED_MODIFIER);
+        }
+
+        //Player inputs
+        if (Gdx.input.isKeyPressed(Input.Keys.A) || Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.A)) {
+            playerInputProcessor.keyDown(Input.Keys.A);
+        } else if (Gdx.input.isKeyPressed(Input.Keys.D) || Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.D)) {
+            playerInputProcessor.keyDown(Input.Keys.D);
+        } else if (Gdx.input.isKeyPressed(Input.Keys.W) || Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.W)) {
+            playerInputProcessor.keyDown(Input.Keys.W);
+        } else if (Gdx.input.isKeyPressed(Input.Keys.S) || Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.S)) {
+            playerInputProcessor.keyDown(Input.Keys.S);
+        }
+
+        //if 2 keys pressed at the same time, move diagonally (player)
+        if (Gdx.input.isKeyPressed(Input.Keys.A) && Gdx.input.isKeyPressed(Input.Keys.W)) {
+           playerInputProcessor.keyDown2(Input.Keys.A, Input.Keys.W, PLAYER_DIAGONAL_MOVE_SPEED_MODIFIER);
+        }
+        if (Gdx.input.isKeyPressed(Input.Keys.D) && Gdx.input.isKeyPressed(Input.Keys.W)) {
+            playerInputProcessor.keyDown2(Input.Keys.D, Input.Keys.W, PLAYER_DIAGONAL_MOVE_SPEED_MODIFIER);
+        }
+        if (Gdx.input.isKeyPressed(Input.Keys.A) && Gdx.input.isKeyPressed(Input.Keys.S)) {
+            playerInputProcessor.keyDown2(Input.Keys.A, Input.Keys.S, PLAYER_DIAGONAL_MOVE_SPEED_MODIFIER);
+        }
+        if (Gdx.input.isKeyPressed(Input.Keys.D) && Gdx.input.isKeyPressed(Input.Keys.S)) {
+            playerInputProcessor.keyDown2(Input.Keys.D, Input.Keys.S, PLAYER_DIAGONAL_MOVE_SPEED_MODIFIER);
+        }
+
+        //reset player velocity if no keys are pressed
+        if (!Gdx.input.isKeyPressed(Input.Keys.A) && !Gdx.input.isKeyPressed(Input.Keys.D) &&
+                !Gdx.input.isKeyPressed(Input.Keys.W) && !Gdx.input.isKeyPressed(Input.Keys.S)) {
+            player.setLinearVelocity(0, 0);
+        }
+
+        //if touch dragged, use action from cameraInputProcessor
+//        if (Gdx.input.isTouched()) {
+//            cameraInputProcessor.touchDragged(Gdx.input.getX(), Gdx.input.getY(), 0);
+//        }
+
     }
     public void cameraUpdate(float delta) {
         if (cameraLock) {

--- a/core/src/aaa/main/screens/MainScreen.java
+++ b/core/src/aaa/main/screens/MainScreen.java
@@ -1,6 +1,7 @@
 package aaa.main.screens;
 
 import aaa.main.AntGame;
+import aaa.main.game.Colony;
 import aaa.main.game.PlayerInputProcessor;
 import aaa.main.stages.PauseMenu;
 import aaa.main.game.CameraInputProcessor;
@@ -32,7 +33,6 @@ public class MainScreen extends ScreenAdapter {
 
     private boolean DEBUG = false;
     private Box2DDebugRenderer b2dr;
-    private OrthographicCamera camera;
     private World world;
     private Body player ,borderUP, borderDOWN, borderLEFT, borderRIGHT, circle;
     private final float SCALE = 2.0f;
@@ -43,6 +43,10 @@ public class MainScreen extends ScreenAdapter {
     CameraInputProcessor cameraInputProcessor;
     PlayerInputProcessor playerInputProcessor;
     InputMultiplexer inputMultiplexer;
+
+    private Colony colony1;
+    private Colony colony2;
+
     public MainScreen(final AntGame game) {
         inputMultiplexer = new InputMultiplexer();
 
@@ -61,6 +65,9 @@ public class MainScreen extends ScreenAdapter {
         b2dr = new Box2DDebugRenderer();
 
         player = createBox(0,0,32,32,false);
+
+        colony1 = new Colony("test1", createBox(128,128,32,32,true), camera);
+        colony2 = new Colony("test2", createBox(-128,-128,32,32,true), camera);
 
         playerInputProcessor = new PlayerInputProcessor(player);
 
@@ -112,6 +119,8 @@ public class MainScreen extends ScreenAdapter {
         //for future use when debugging is needed
         b2dr.render(world, camera.combined.scl(PPM));
 
+        game.batch.setProjectionMatrix(camera.combined);
+
         if (game.gameState.paused && !pauseOpened) {
             pauseMenu.setInput();
             pauseOpened = true;
@@ -121,7 +130,8 @@ public class MainScreen extends ScreenAdapter {
         }
         game.batch.begin();
         stage.draw();
-        antColonies[0].render(game.batch);
+        colony1.render(game.batch);
+        colony2.render(game.batch);
         if (game.gameState.paused) {
             this.pauseMenu.draw(delta);
         }
@@ -221,7 +231,7 @@ public class MainScreen extends ScreenAdapter {
 
         //if 2 keys pressed at the same time, move diagonally (player)
         if (Gdx.input.isKeyPressed(Input.Keys.A) && Gdx.input.isKeyPressed(Input.Keys.W)) {
-           playerInputProcessor.keyDown2(Input.Keys.A, Input.Keys.W, PLAYER_DIAGONAL_MOVE_SPEED_MODIFIER);
+            playerInputProcessor.keyDown2(Input.Keys.A, Input.Keys.W, PLAYER_DIAGONAL_MOVE_SPEED_MODIFIER);
         }
         if (Gdx.input.isKeyPressed(Input.Keys.D) && Gdx.input.isKeyPressed(Input.Keys.W)) {
             playerInputProcessor.keyDown2(Input.Keys.D, Input.Keys.W, PLAYER_DIAGONAL_MOVE_SPEED_MODIFIER);

--- a/core/src/aaa/main/util/Constants.java
+++ b/core/src/aaa/main/util/Constants.java
@@ -15,6 +15,8 @@ public final class Constants {
 
     public static final float MIN_ZOOM = 0.3f;
 
+    public static final float CAMERA_RETURN_SPEED = 0.1f;
+
     //Colony constants
     public static final float DEFAULT_HEALTH = 150;
     public static final float DEFAULT_RESOURCES = 25;

--- a/core/src/aaa/main/util/Constants.java
+++ b/core/src/aaa/main/util/Constants.java
@@ -24,4 +24,18 @@ public final class Constants {
     public static final int MAX_ANTS = 25;
     public static final int GLOBAL_MAX_COLONY = 5;
     public static final String COLONY_TEXTURE_FILE = "col_nest.png";
+
+    //camera movement constants
+    public static final float CAMERA_RETURN_SPEED = 2f;
+
+    public static final float CAMERA_MOVE_SPEED = 8; //number is in pixels
+
+    public static final float CAMERA_DIAGONAL_MOVE_SPEED_MODIFIER = 2.5f; //best results between 2f-3f
+
+
+    //player movement constants
+
+    public static final float PLAYER_MOVE_SPEED = 5f;
+
+    public static final float PLAYER_DIAGONAL_MOVE_SPEED_MODIFIER = 0.7f; //number should be between 0 and 1, gets multiplied by PLAYER_MOVE_SPEED
 }

--- a/core/src/aaa/main/util/Constants.java
+++ b/core/src/aaa/main/util/Constants.java
@@ -26,8 +26,6 @@ public final class Constants {
     public static final String COLONY_TEXTURE_FILE = "col_nest.png";
 
     //camera movement constants
-    public static final float CAMERA_RETURN_SPEED = 2f;
-
     public static final float CAMERA_MOVE_SPEED = 8; //number is in pixels
 
     public static final float CAMERA_DIAGONAL_MOVE_SPEED_MODIFIER = 2.5f; //best results between 2f-3f


### PR DESCRIPTION
Scrapped click and drag, for now, and used this ticket to implement key controls for cameras. There are constants added that control camera/player speed. The modifiers for these are for diagonal movment (because you would move really fast if not modified for diagonal). Worked on player movment a bit too. Let me know what your thoughts are on click/drag vs arrow key movement. Decision was made mostly for the sake of time and to work on other more impactful tasks. Planning on working on context switching next (aka, click on another object such as a colony or ant/group to focus camera context to object clicked on.