### PR TITLE
Ant 34 focus on object

### DIFF
--- a/core/src/aaa/main/game/input/CameraInputProcessor.java
+++ b/core/src/aaa/main/game/input/CameraInputProcessor.java
@@ -8,6 +8,9 @@ import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.math.Vector3;
 import aaa.main.screens.MainScreen;
+import aaa.main.game.map.Ant;
+import aaa.main.game.map.Colony;
+import com.badlogic.gdx.physics.box2d.Body;
 
 import static aaa.main.util.Constants.CAMERA_MOVE_SPEED;
 
@@ -19,6 +22,8 @@ public class CameraInputProcessor implements InputProcessor {
     public CameraInputProcessor(OrthographicCamera camera) {
         this.camera = camera;
     }
+
+    public Body selectedObject = null;
 
     //handler for horizontal/vertical movement
     @Override
@@ -56,6 +61,11 @@ public class CameraInputProcessor implements InputProcessor {
         if (keycode == Input.Keys.DOWN) {
             //move down
             camera.translate(0, -CAMERA_MOVE_SPEED);
+        }
+
+        if (keycode == Input.Keys.C)
+        {
+
         }
         return false;
     }
@@ -99,6 +109,30 @@ public class CameraInputProcessor implements InputProcessor {
         return false;
     }
 
+    public boolean touchDown(int screenX, int screenY, int pointer, int button, MainScreen screen) {
+        //logic for switching player context should be to check if position clicked is on a object
+        //checks would have to be in world coordinates, not screen coordinates
+        //also would need to check for clicks on UI buttons, should be in screen coordinates then
+
+        //print the click position in world coordinates
+        Vector3 clickPos = camera.unproject(new Vector3(screenX, screenY, 0));
+
+        //print the click position in world coordinates
+        System.out.println("Click position: " + clickPos.x + ", " + clickPos.y);
+
+        //print all colony locations
+        //for (Colony colony : screen.colonies) {
+        //    System.out.println("Colony position: " + colony.getColonyBody().getPosition().x*Constants.PPM + ", " + colony.getColonyBody().getPosition().y*Constants.PPM);
+        //}
+
+        //print all colony coordinates
+        String result = isBodyClicked(clickPos, screen);
+        if (result != null) {
+            System.out.println(result);
+        }
+        return false;
+    }
+
     @Override
     public boolean touchUp(int screenX, int screenY, int pointer, int button) {
         return false;
@@ -122,5 +156,45 @@ public class CameraInputProcessor implements InputProcessor {
     @Override
     public boolean scrolled(float amountX, float amountY) {
         return false;
+    }
+
+    public void setSelectedObject(Body body) {
+        selectedObject = body;
+    }
+
+    //uncomment comments below for debugging, works as expected so far
+    //switches control context to clicked body, focuses camera on clicked body (does not follow body, need to implement if wanted)
+    private String isBodyClicked(Vector3 clickPos, MainScreen screen) {
+        for (Colony colony : screen.colonies) {
+            float colonyXMin = (colony.getColonyBody().getPosition().x*Constants.PPM) - ((Constants.COLONY_WIDTH * Constants.MAP_TILE_PIXELS)/2);
+            float colonyXMax = (colony.getColonyBody().getPosition().x*Constants.PPM) + ((Constants.COLONY_WIDTH * Constants.MAP_TILE_PIXELS)/2);
+            float colonyYMin = (colony.getColonyBody().getPosition().y*Constants.PPM) - ((Constants.COLONY_HEIGHT * Constants.MAP_TILE_PIXELS)/2);
+            float colonyYMax = (colony.getColonyBody().getPosition().y*Constants.PPM) + ((Constants.COLONY_HEIGHT * Constants.MAP_TILE_PIXELS)/2);
+            if (clickPos.x >= colonyXMin && clickPos.x <= colonyXMax && clickPos.y >= colonyYMin && clickPos.y <= colonyYMax) {
+                //System.out.println("Colony found: " + colony.getName());
+                screen.focusCameraOnColony(colony.getColonyBody());
+                setSelectedObject(colony.getColonyBody());
+                screen.setCameraLock(true);
+            } else {
+                //System.out.println("Colony not found");
+            }
+            //check if click was on colony ant
+            for (Ant ant : colony.getAntsList()) {
+                float antXMin = (ant.getAntBody().getPosition().x*Constants.PPM) - ((Constants.ANT_WIDTH * Constants.MAP_TILE_PIXELS)/2);
+                float antXMax = (ant.getAntBody().getPosition().x*Constants.PPM) + ((Constants.ANT_WIDTH * Constants.MAP_TILE_PIXELS)/2);
+                float antYMin = (ant.getAntBody().getPosition().y*Constants.PPM) - ((Constants.ANT_HEIGHT * Constants.MAP_TILE_PIXELS)/2);
+                float antYMax = (ant.getAntBody().getPosition().y*Constants.PPM) + ((Constants.ANT_HEIGHT * Constants.MAP_TILE_PIXELS)/2);
+                if (clickPos.x >= antXMin && clickPos.x <= antXMax && clickPos.y >= antYMin && clickPos.y <= antYMax) {
+                    //System.out.println("Ant found: " + ant.getName());
+                    screen.focusCameraOnAnt(ant.getAntBody());
+                    screen.setPlayerInputProcessor(ant.getAntBody());
+                    setSelectedObject(ant.getAntBody());
+                    screen.setCameraLock(true);
+                } else {
+                    //System.out.println("Ant not found");
+                }
+            }
+        }
+        return null;
     }
 }

--- a/core/src/aaa/main/game/map/Ant.java
+++ b/core/src/aaa/main/game/map/Ant.java
@@ -131,5 +131,40 @@ public class Ant extends MapObject {
         sprite.setOrigin(sprite.getWidth()/2, sprite.getHeight()/2);
     }
 
+    public Body getAntBody() {
+        return antBody;
+    }
+
+    public String getName() {
+        return antType;
+    }
+
+    public void setName(String newName) {
+        antType = newName;
+    }
+
+    public int getHealth() {
+        return health;
+    }
+
+    public void setHealth(int newHealth) {
+        health = newHealth;
+    }
+
+    public int getAttack() {
+        return attack;
+    }
+
+    public void setAttack(int newAttack) {
+        attack = newAttack;
+    }
+
+    public Colony getColony() {
+        return colony;
+    }
+
+    public void setColony(Colony newColony) {
+        colony = newColony;
+    }
 
 }

--- a/core/src/aaa/main/screens/MainScreen.java
+++ b/core/src/aaa/main/screens/MainScreen.java
@@ -40,7 +40,7 @@ public class MainScreen extends ScreenAdapter {
 
     private MapManager mapManager;
     private MapObjectHandler moh;
-    private Body player;
+    public Body player;
     private final float SCALE = 2.0f;
 
     boolean cameraLock = false;
@@ -73,7 +73,9 @@ public class MainScreen extends ScreenAdapter {
         world = new World(new Vector2(0, 0), false);
         b2dr = new Box2DDebugRenderer();
 
-        player = RenderUtils.createBox(0,0,32,32,false, world);
+        player = RenderUtils.createBox(0,0,32,32,true, world);
+
+        cameraInputProcessor.selectedObject = player;
 
 
         //Colony creation testing
@@ -87,8 +89,16 @@ public class MainScreen extends ScreenAdapter {
             ColonyUtils.addAnt(c, "Worker", camera, world, moh);
         }
 
-        playerInputProcessor = new PlayerInputProcessor(player);
+
+        //print all colonies and their world positions
+        for (Colony c : colonies) {
+            System.out.println("Colony " + c.getName() + " at " + c.getColonyBody().getPosition().x*PPM + ", " + c.getColonyBody().getPosition().y*PPM );
+        }
+
+        //this will eventually be removed
+        setPlayerInputProcessor(player);
         menusInputProcessor = new MenusInputProcessor(game.gameState);
+
 
         inputMultiplexer.addProcessor(playerInputProcessor);
         inputMultiplexer.addProcessor(cameraInputProcessor);
@@ -234,6 +244,12 @@ public class MainScreen extends ScreenAdapter {
             cameraInputProcessor.keyDown2(Input.Keys.DOWN, CAMERA_DIAGONAL_MOVE_SPEED_MODIFIER);
         }
 
+        //if c is pressed, lock camera to selected object
+        if (Gdx.input.isKeyPressed(Input.Keys.C) || Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.C)) {
+            cameraInputProcessor.keyDown(Input.Keys.C);
+            setCameraLock(false);
+        }
+
         //Player inputs
         if (Gdx.input.isKeyPressed(Input.Keys.A) || Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.A)) {
             playerInputProcessor.keyDown(Input.Keys.A);
@@ -259,11 +275,18 @@ public class MainScreen extends ScreenAdapter {
             playerInputProcessor.keyDown2(Input.Keys.D, Input.Keys.S, PLAYER_DIAGONAL_MOVE_SPEED_MODIFIER);
         }
 
+        //if mouse is clicked call camerainputprocessor touchdown with click position
+        if (Gdx.input.isButtonPressed(Input.Buttons.LEFT)) {
+            cameraInputProcessor.touchDown(Gdx.input.getX(), Gdx.input.getY(), 0, 0, this);
+        }
+
         //reset player velocity if no keys are pressed
         if (!Gdx.input.isKeyPressed(Input.Keys.A) && !Gdx.input.isKeyPressed(Input.Keys.D) &&
                 !Gdx.input.isKeyPressed(Input.Keys.W) && !Gdx.input.isKeyPressed(Input.Keys.S)) {
             player.setLinearVelocity(0, 0);
         }
+
+
 
 
 
@@ -280,6 +303,20 @@ public class MainScreen extends ScreenAdapter {
 
     public void setCameraLock(boolean val) {
         this.cameraLock = val;
+    }
+
+    public void setPlayerInputProcessor(Body body) {
+        this.playerInputProcessor = new PlayerInputProcessor(body);
+    }
+
+    public void focusCameraOnColony(Body colony) {
+        player = colony;
+        camera.position.set(colony.getPosition().x * PPM, colony.getPosition().y * PPM, 0);
+    }
+
+    public void focusCameraOnAnt(Body ant) {
+        player = ant;
+        camera.position.set(ant.getPosition().x * PPM, ant.getPosition().y * PPM, 0);
     }
 
 }


### PR DESCRIPTION
Added functionality to be able to switch controls context to ants or colony (colony doesn't do anything yet, but clicking on colony features can be easily implemented at this stage.) Clicking on a body will center the camera around it, for colony thats all it does. for ants it allows you to control them just like you would be for a player. 

Added some ant functions for getters and setters.